### PR TITLE
update clean-webpack-plugin in-order and use cleanAfterEveryBuildPatterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "babel-core": "^7.0.0-0",
     "babel-jest": "^24.5.0",
     "babel-loader": "^8.0.5",
-    "clean-webpack-plugin": "^2.0.0",
+    "clean-webpack-plugin": "^2.0.1",
     "copy-webpack-plugin": "^5.0.1",
     "css-loader": "^2.1.1",
     "html-webpack-plugin": "^3.2.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,9 +18,7 @@ module.exports = {
   devtool: "source-map",
   plugins: [
     new CleanWebpackPlugin({
-      cleanStaleWebpackAssets: false, // needed so icons are not deleted in watch mode
-      // cleanOnceBeforeBuildPatterns: ["**/*", "!icons/*.png"],
-      // cleanAfterEveryBuildPatterns: [],
+      cleanAfterEveryBuildPatterns: ['!icons/*.png'], // needed so icons are not deleted in watch mode
     }),
     new HtmlWebpackPlugin({
       title: "Org Protocol Browser Extension",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2089,10 +2089,10 @@ clean-css@4.2.x:
   dependencies:
     source-map "~0.6.0"
 
-clean-webpack-plugin@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/clean-webpack-plugin/-/clean-webpack-plugin-2.0.0.tgz#051235deafc240907536c2bcac8531649f4589e5"
-  integrity sha512-xH9RUgXaeeW2VmtygwcGNFAmYzRrv93uHk+c5gYA4qHmX1gpRfjScsvvCT7PcUb0Z5Y30H/pswTM1qYApVLBXA==
+clean-webpack-plugin@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/clean-webpack-plugin/-/clean-webpack-plugin-2.0.1.tgz#2241526b0030aa0249e78714471298f867fc2829"
+  integrity sha512-vway5pXGVd91bicwjaf8j188Al6VMf9R9Ekl6q0qeiaWStRsOOXuh4qtjX1UrUvmz5XevQVCdjBuzr4Tzsnpog==
   dependencies:
     del "^4.0.0"
 


### PR DESCRIPTION
Your webpack config revealed a [bug in clean-webpack-plugin](https://github.com/johnagan/clean-webpack-plugin/pull/112). We've successfully published a fix and here is a PR resolving your issue with  the icons being incorrectly removed.